### PR TITLE
allow learning rate to be passed

### DIFF
--- a/src/Numeric/AD/Newton.hs
+++ b/src/Numeric/AD/Newton.hs
@@ -259,14 +259,17 @@ iHat t c e =
 -- set, it performs the update for each training example.
 --
 -- It uses reverse mode automatic differentiation to compute the gradient
--- The learning rate is constant through out, and is set to 0.001
+-- The learning rate 𝜂 is constant throughout; if 0 then 0.001 is used.
 stochasticGradientDescent :: (Traversable f, Fractional a, Ord a)
-  => (forall s. Reifies s Tape => e -> f (Reverse s a) -> Reverse s a)
+  => a
+  -> (forall s. Reifies s Tape => e -> f (Reverse s a) -> Reverse s a)
   -> [e]
   -> f a
   -> [f a]
-stochasticGradientDescent errorSingle d0 x0 = go xgx0 0.001 dLeft
+stochasticGradientDescent eta errorSingle d0 x0 = go xgx0 eta0 dLeft
   where
+    eta0 = if eta == 0 then defaultEta else eta
+    defaultEta = 0.001
     dLeft = tail $ cycle d0
     xgx0 = Reverse.gradWith (,) (errorSingle (head d0)) x0
     go xgx !eta d

--- a/src/Numeric/AD/Newton.hs
+++ b/src/Numeric/AD/Newton.hs
@@ -261,8 +261,8 @@ iHat t c e =
 -- It uses reverse mode automatic differentiation to compute the gradient
 -- The learning rate is constant through out, and is set to 0.001
 stochasticGradientDescent :: (Traversable f, Fractional a, Ord a)
-  => (forall s. Reifies s Tape => f (Scalar a) -> f (Reverse s a) -> Reverse s a)
-  -> [f (Scalar a)]
+  => (forall s. Reifies s Tape => e -> f (Reverse s a) -> Reverse s a)
+  -> [e]
   -> f a
   -> [f a]
 stochasticGradientDescent errorSingle d0 x0 = go xgx0 0.001 dLeft


### PR DESCRIPTION
This just allows a single learning rate to be passed, with a default from passing zero.

Really should pass a list of learning rates, which is cycled through. So pass `[]` to get the default of a constant `0.001`, pass `[0.0005]` to get a constant `0.0005`, and pass, e.g., `[1/sqrt t | t <- [1e6..]]` to get a schedule. If you're careful you could even implement an adaptive learning rate by closing the loop and making the learning schedule a function of the output of the optimizer.